### PR TITLE
Fix no robot case and late register

### DIFF
--- a/orwell/proxy_robots/action.py
+++ b/orwell/proxy_robots/action.py
@@ -40,8 +40,8 @@ class Action(object):
         """
         Call the wrapped function.
         """
-        self._doer()
-        self._update_status()
+        sent = self._doer()
+        self._update_status(sent)
 
     def reset(self):
         """
@@ -56,16 +56,23 @@ class Action(object):
         """
         return self._status
 
-    def _update_status(self):
+    @property
+    def repeat(self):
+        return self._repeat
+
+    def _update_status(self, sent=False):
         """
         Update the status of the action.
         """
         updated = False
         if Status.created == self._status:
-            if self._proxy:
-                self._status = Status.pending
+            if not sent:
+                self._status = Status.failed
             else:
-                self._status = Status.waiting
+                if self._proxy:
+                    self._status = Status.pending
+                else:
+                    self._status = Status.waiting
             updated = True
         if not updated:
             if Status.pending == self._status:

--- a/orwell/proxy_robots/devices.py
+++ b/orwell/proxy_robots/devices.py
@@ -6,7 +6,7 @@ LOGGER = logging.getLogger(__name__)
 
 class FakeDevice(object):
     def __init__(self):
-        self._address = None
+        self._address = "1.2.3.4"
 
     def __del__(self):
         """

--- a/orwell/proxy_robots/engine.py
+++ b/orwell/proxy_robots/engine.py
@@ -21,9 +21,6 @@ class Engine(object):
         Check all pending actions to see if a notification has been received.
         Run all the actions that are in the created state.
         """
-        # LOGGER.debug('Engine.step()')
-        # LOGGER.debug('_created_actions = ' + str(self._created_actions))
-        # LOGGER.debug('_pending_actions = ' + str(self._pending_actions))
         to_remove = []
         new_actions = []
         for action in self._pending_actions:

--- a/orwell/proxy_robots/robot.py
+++ b/orwell/proxy_robots/robot.py
@@ -117,6 +117,8 @@ class Robot(object):
                 Messages.Register.name).encode()
             payload += message.SerializeToString()
             self._message_hub_wrapper.message_hub.post(payload)
+            return True
+        return False
 
     def notify(
             self,


### PR DESCRIPTION
Upgrade python-common to send broadcast request in a dedicated thread, thus
not blocking the main thread.
Make it possible to launch the proxy with no robot (--ports-count 0).
Register is now sent properly if the game server was not available from start.
Fix logging.